### PR TITLE
Fixed casing of Crypto folder in Makefile

### DIFF
--- a/Projects/Applications/DRAGINO-LRWAN-AT/Makefile
+++ b/Projects/Applications/DRAGINO-LRWAN-AT/Makefile
@@ -8,7 +8,7 @@ $(PROJECT)_SOURCE := $(wildcard src/*.c)  \
     $(wildcard $(TREMO_SDK_PATH)/Drivers/peripheral/src/*.c)  \
 	$(wildcard $(TREMO_SDK_PATH)/Drivers/sensor/*.c)  \
     $(wildcard $(TREMO_SDK_PATH)/Middlewares/LoRa/system/*.c)  \
-    $(wildcard $(TREMO_SDK_PATH)/Middlewares/LoRa/system/crypto/*.c)  \
+    $(wildcard $(TREMO_SDK_PATH)/Middlewares/LoRa/system/Crypto/*.c)  \
     $(wildcard $(TREMO_SDK_PATH)/Middlewares/LoRa/radio/sx126x/*.c)  \
     $(wildcard $(TREMO_SDK_PATH)/Middlewares/LoRa/driver/*.c) \
     $(wildcard $(TREMO_SDK_PATH)/Middlewares/LoRa/LoRaMac-node/region/*.c) \
@@ -28,7 +28,7 @@ $(PROJECT)_INC_PATH := inc \
     $(TREMO_SDK_PATH)/Middlewares/LoRa/radio \
     $(TREMO_SDK_PATH)/Middlewares/LoRa/radio/sx126x \
 	$(TREMO_SDK_PATH)/Middlewares/LoRa/system \
-    $(TREMO_SDK_PATH)/Middlewares/LoRa/system/crypto \
+    $(TREMO_SDK_PATH)/Middlewares/LoRa/system/Crypto \
     $(TREMO_SDK_PATH)/Projects/Applications/DRAGINO-LRWAN-AT/inc
 	
 $(PROJECT)_CFLAGS  := -Wall -Os -ffunction-sections -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -fsingle-precision-constant -std=gnu99 -fno-builtin-printf -fno-builtin-sprintf -fno-builtin-snprintf


### PR DESCRIPTION
On case-sensitive filesystems like `ext4` the folder `$(wildcard $(TREMO_SDK_PATH)/Middlewares/LoRa/system/crypto/` does not exist, as it is actually called `Crypto` instead of `crypto`.   This causes the builds to fail.  

By renaming the path in the `Makefile` builds succeeded again.  

