### PR TITLE
Added AT+CLINKCHECK command

### DIFF
--- a/Projects/Applications/DRAGINO-LRWAN-AT/inc/command.h
+++ b/Projects/Applications/DRAGINO-LRWAN-AT/inc/command.h
@@ -55,6 +55,7 @@
 #define AT_RECV       "+RECV"
 #define AT_VER        "+VER"
 #define AT_CFM        "+CFM"
+#define AT_CLINKCHECK "+CLINKCHECK"
 #define AT_CFS        "+CFS"
 #define AT_SNR        "+SNR"
 #define AT_RSSI       "+RSSI"

--- a/Projects/Applications/DRAGINO-LRWAN-AT/inc/lora_app.h
+++ b/Projects/Applications/DRAGINO-LRWAN-AT/inc/lora_app.h
@@ -320,6 +320,21 @@ void lora_config_tx_datarate_set(int8_t TxDataRate);
  */ 
 int8_t lora_config_tx_datarate_get(void );
 
+
+/**
+ * @brief  get linkcheck
+ * @param  None
+ * @retval linkcheck mode
+ */
+uint8_t lora_config_linkcheck_get(void);
+
+/**
+ * @brief  set linkcheck
+ * @param  linkcheck mode
+ * @retval None
+ */
+void lora_config_linkcheck_set(uint8_t LinkCheck);
+
 /**
   * @brief  set 
   * @param  

--- a/Projects/Applications/DRAGINO-LRWAN-AT/src/command.c
+++ b/Projects/Applications/DRAGINO-LRWAN-AT/src/command.c
@@ -139,6 +139,7 @@ static int at_recv_func(int opt, int argc, char *argv[]);
 static int at_recvb_func(int opt, int argc, char *argv[]);
 static int at_ver_func(int opt, int argc, char *argv[]);
 static int at_cfm_func(int opt, int argc, char *argv[]);
+static int at_clinkcheck_func(int opt, int argc, char *argv[]);
 //static int at_cfs_func(int opt, int argc, char *argv[]);
 static int at_snr_func(int opt, int argc, char *argv[]);
 static int at_rssi_func(int opt, int argc, char *argv[]);
@@ -208,6 +209,7 @@ static at_cmd_t g_at_table[] = {
 		{AT_RECVB,at_recvb_func},
 		{AT_RECV,at_recv_func},
 		{AT_VER, at_ver_func},
+                {AT_CLINKCHECK, at_clinkcheck_func},
 		{AT_CFM, at_cfm_func},
 		{AT_SNR, at_snr_func},
 		{AT_RSSI, at_rssi_func},
@@ -3106,6 +3108,38 @@ static int at_devicetimereq_func(int opt, int argc, char *argv[])
 					snprintf((char *)atcmd, ATCMD_SIZE, "Device time req\r\n");
 					break;
 				}
+        default: break;
+    }
+
+    return ret;
+}
+
+static int at_clinkcheck_func(int opt, int argc, char *argv[])
+{
+    int ret = LWAN_ERROR;
+    uint8_t checkValue;
+
+    switch(opt) {
+        case DESC_CMD: {
+            ret = LWAN_SUCCESS;
+            snprintf((char *)atcmd, ATCMD_SIZE, "Set linkcheck mode (0-1)\r\n");
+            break;
+        }
+        case SET_CMD: {
+            if(argc < 1) break;
+            checkValue = strtol((const char *)argv[0], NULL, 0);
+            lora_config_linkcheck_set(checkValue);
+            ret = LWAN_SUCCESS;
+
+            if(checkValue==1) {
+              MlmeReq_t mlmeReq;
+              mlmeReq.Type = MLME_LINK_CHECK;
+              LoRaMacMlmeRequest( &mlmeReq );
+            }
+
+            snprintf((char *)atcmd, ATCMD_SIZE, "\r\nOK\r\n");
+            break;
+        }
         default: break;
     }
 

--- a/Projects/Applications/DRAGINO-LRWAN-AT/src/lora_app.c
+++ b/Projects/Applications/DRAGINO-LRWAN-AT/src/lora_app.c
@@ -134,6 +134,7 @@ uint8_t lora_packet_send_complete_status=0;
    LoraConfirm_t ReqAck;      /*< ENABLE if acknowledge is requested */
    McpsConfirm_t *McpsConfirm;  /*< pointer to the confirm structure */
    int8_t TxDatarate;
+   uint8_t linkCheck;
  } lora_configuration_t;
  
 /**
@@ -189,7 +190,8 @@ static lora_configuration_t lora_config =
   .Snr = 0,
   .ReqAck = LORAWAN_UNCONFIRMED_MSG,
   .McpsConfirm = NULL,
-  .TxDatarate = 0
+  .TxDatarate = 0,
+  .linkCheck = 0
 };
 
 
@@ -1006,6 +1008,14 @@ LoraState_t lora_config_isack_get(void)
   }
 }
 
+void lora_config_linkcheck_set(uint8_t LinkCheck)
+{
+  lora_config.linkCheck = LinkCheck;
+}
+
+uint8_t lora_config_linkcheck_get() { return lora_config.linkCheck; }
+
+
 void Flash_store_key(void)
 {
 	  uint8_t store_key_in_flash[128];
@@ -1249,6 +1259,8 @@ void Flash_Store_Config(void)
 	store_config_in_flash[73]=down_check;
 	store_config_in_flash[74]=decrypt_flag;
 	store_config_in_flash[75]=mac_response_flag;
+
+        store_config_in_flash[76]=lora_config.linkCheck;
 	
 	flash_erase_page(FLASH_USER_START_ADDR_CONFIG);
 	if(flash_program_bytes(FLASH_USER_START_ADDR_CONFIG,store_config_in_flash,128)==ERRNO_FLASH_SEC_ERROR)
@@ -1411,7 +1423,8 @@ void Flash_Read_Config(void)
 	
 	down_check=read_config_in_flash[73];	
 	decrypt_flag=read_config_in_flash[74];	
-	mac_response_flag=read_config_in_flash[75];	
+	mac_response_flag=read_config_in_flash[75];
+	lora_config.linkCheck = read_config_in_flash[76];
 }
 
 static void new_firmware_update(void)


### PR DESCRIPTION
This MR adds the `AT+CLINKCHECK` command to the firmware.  It relies mostly on existing functionality already available in the LoRaWan middleware.  
This implementation is based on the code available in [ASR6601 SDK repository](https://github.com/asrlora/asr_lora_6601/blob/284621eb192318e90f95f0ab9ac9cded71a56d2e/lora/linkwan/linkwan_ica_at.c#L1090).